### PR TITLE
Fix: Corrected casing for 'users' table name

### DIFF
--- a/lib/src/providers/user_profile_provider.dart
+++ b/lib/src/providers/user_profile_provider.dart
@@ -32,7 +32,7 @@ class UserProfileProvider with ChangeNotifier {
 
     try {
       final data = await _supabase
-          .from('Users')
+          .from('users')
           .select()
           .eq('id', userId)
           .single();

--- a/supabase/migrations/20250817125900_create_users_table_first.sql
+++ b/supabase/migrations/20250817125900_create_users_table_first.sql
@@ -1,5 +1,5 @@
 -- Create the Users table first
-CREATE TABLE IF NOT EXISTS Users (
+CREATE TABLE IF NOT EXISTS users (
   id UUID PRIMARY KEY,
   email TEXT UNIQUE,
   username TEXT,

--- a/supabase/migrations/20250817130100_create_functions.sql
+++ b/supabase/migrations/20250817130100_create_functions.sql
@@ -41,7 +41,7 @@ BEGIN
   user_id := auth.uid();
   
   -- Decrement the user's credit count
-  UPDATE Users 
+  UPDATE users 
   SET credits_remaining = credits_remaining - 1 
   WHERE id = user_id AND credits_remaining > 0;
 END;

--- a/supabase/migrations/20250817130300_add_foreign_key_constraints.sql
+++ b/supabase/migrations/20250817130300_add_foreign_key_constraints.sql
@@ -4,21 +4,21 @@
 ALTER TABLE pins
   ADD CONSTRAINT fk_pins_owner_id
   FOREIGN KEY (owner_id)
-  REFERENCES Users(id)
+  REFERENCES users(id)
   ON DELETE CASCADE;
 
 -- Add foreign key constraints to boards table
 ALTER TABLE boards
   ADD CONSTRAINT fk_boards_user_id
   FOREIGN KEY (user_id)
-  REFERENCES Users(id)
+  REFERENCES users(id)
   ON DELETE CASCADE;
 
 -- Add foreign key constraints to user_likes table
 ALTER TABLE user_likes
   ADD CONSTRAINT fk_user_likes_user_id
   FOREIGN KEY (user_id)
-  REFERENCES Users(id)
+  REFERENCES users(id)
   ON DELETE CASCADE,
   ADD CONSTRAINT fk_user_likes_pin_id
   FOREIGN KEY (pin_id)


### PR DESCRIPTION
Corrected casing for 'users' table name